### PR TITLE
fix package: peerDependencies: suppress warning for acorn v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint -c .eslintrc.json ."
   },
   "peerDependencies": {
-    "acorn": "^6.1.0"
+    "acorn": ">=6.1.0"
   },
   "dependencies": {
     "acorn-bigint": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint -c .eslintrc.json ."
   },
   "peerDependencies": {
-    "acorn": ">=6.1.0"
+    "acorn": ">=6.1.0 <8.0.0"
   },
   "dependencies": {
     "acorn-bigint": "^0.3.1",


### PR DESCRIPTION
Suppress this warning for `acorn v7` (acornjs/acorn#862)
```
acorn-stage3@2.0.0" has incorrect peer dependency "acorn@^6.1.0"
```