### PR TITLE
Update acorn-class-fields version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "acorn-bigint": "^0.3.1",
-    "acorn-class-fields": "^0.3.1",
+    "acorn-class-fields": "^0.3.2",
     "acorn-dynamic-import": "^4.0.0",
     "acorn-export-ns-from": "^0.1.0",
     "acorn-import-meta": "^1.0.0",


### PR DESCRIPTION
acorn-class-fields 0.3.2 includes a pull request which upgrades acorn-private-class-elements to 2.0.
acorn-private-class-elements seems to compatible with acorn 7.