### PR TITLE
Update README.md to current Stage 3 feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ This is a plugin for [Acorn](http://marijnhaverbeke.nl/acorn/) - a tiny, fast Ja
 
 It implements support for all missing [ECMAScript stage 3 proposals](https://github.com/tc39/proposals/blob/master/README.md#stage-3). Neither loose mode nor walk are currently supported.
 
-- [Numeric Separators](https://github.com/tc39/proposal-numeric-separator) via [acorn-numeric-separator](https://www.npmjs.org/package/acorn-numeric-separator)
 - [Class field declarations](https://github.com/tc39/proposal-class-fields) via [acorn-class-fields](https://www.npmjs.org/package/acorn-class-fields)
 - [Private methods and getter/setters for JavaScript classes](https://github.com/tc39/proposal-private-methods) via [acorn-private-methods](https://www.npmjs.org/package/acorn-private-methods)
 - [Static class features](https://github.com/tc39/proposal-static-class-features) via [acorn-static-class-features](https://www.npmjs.org/package/acorn-static-class-features)
-- [Logical assignments](https://github.com/tc39/proposal-logical-assignment) via [acorn-logical-assignment](https://github.com/acornjs/acorn-logical-assignment)
 
 ## Usage
 


### PR DESCRIPTION
In https://github.com/acornjs/acorn-stage3/commit/98d90e9e4ea19d75b82dc970cea1284801d7a6c9, Numeric Separators and Logical Assignment were removed from the plugin (owing to them being Stage 4 and available in acorn v7.4/8).

The [overview](https://github.com/acornjs/acorn-stage3/commit/98d90e9e4ea19d75b82dc970cea1284801d7a6c9#diff-7a7987404e86a043b133f56a86fd282421f207557d254dc43ac4bb0bae8e7915) and [code](https://github.com/acornjs/acorn-stage3/commit/98d90e9e4ea19d75b82dc970cea1284801d7a6c9#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346) were updated, but the README.md still reflects them being part of this package.