### PR TITLE
Update AST node names to match ESTree [breaking change]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.0 (2021-02-08)
+
+* Pick up major updates to class field dependencies plugins with a different AST structure
+  * To match https://github.com/estree/estree/blob/390a050fd2d6a7b69688f1434e0929d7c7455d05/experimental/class-features.md
+
 ## 4.0.0 (2020-08-13)
 
 * Require acorn ^7.4 or ^8

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "acorn": "^7.4 || ^8"
   },
   "dependencies": {
-    "acorn-class-fields": "^0.3.7",
-    "acorn-private-methods": "^0.3.3",
-    "acorn-static-class-features": "^0.2.4"
+    "acorn-class-fields": "^1.0.0",
+    "acorn-private-methods": "^1.0.0",
+    "acorn-static-class-features": "^1.0.0"
   },
-  "version": "4.0.0",
+  "version": "5.0.0",
   "devDependencies": {
     "acorn": "^8",
     "eslint": "^7",

--- a/test/test.js
+++ b/test/test.js
@@ -412,11 +412,11 @@ describe("acorn-stage3", () => {
                 end: 400,
                 body: [
                   newNode(347, {
-                    type: "FieldDefinition",
+                    type: "PropertyDefinition",
                     end: 356,
                     computed: false,
                     key: newNode(347, {
-                      type: "PrivateName",
+                      type: "PrivateIdentifier",
                       end: 349,
                       name: "a"
                     }),
@@ -429,7 +429,7 @@ describe("acorn-stage3", () => {
                     static: false,
                     computed: false,
                     key: newNode(364, {
-                      type: "PrivateName",
+                      type: "PrivateIdentifier",
                       end: 369,
                       name: "getA"
                     }),
@@ -460,7 +460,7 @@ describe("acorn-stage3", () => {
                                   end: 385
                                 }),
                                 property: newNode(386, {
-                                  type: "PrivateName",
+                                  type: "PrivateIdentifier",
                                   end: 388,
                                   name: "a"
                                 }),
@@ -612,11 +612,11 @@ describe("acorn-stage3", () => {
           end: 283,
           body: [
             newNode(14, {
-              type: "FieldDefinition",
+              type: "PropertyDefinition",
               end: 37,
               computed: false,
               key: newNode(14, {
-                type: "PrivateName",
+                type: "PrivateIdentifier",
                 end: 21,
                 name: "secret"
               }),
@@ -629,7 +629,7 @@ describe("acorn-stage3", () => {
                   end: 28
                 }),
                 property: newNode(29, {
-                  type: "PrivateName",
+                  type: "PrivateIdentifier",
                   end: 37,
                   name: "default"
                 }),
@@ -637,11 +637,11 @@ describe("acorn-stage3", () => {
               })
             }),
             newNode(42, {
-              type: "FieldDefinition",
+              type: "PropertyDefinition",
               end: 62,
               computed: false,
               key: newNode(42, {
-                type: "PrivateName",
+                type: "PrivateIdentifier",
                 end: 50,
                 name: "default"
               }),
@@ -659,7 +659,7 @@ describe("acorn-stage3", () => {
               static: false,
               computed: false,
               key: newNode(68, {
-                type: "PrivateName",
+                type: "PrivateIdentifier",
                 end: 78,
                 name: "getSecret"
               }),
@@ -687,7 +687,7 @@ describe("acorn-stage3", () => {
                           end: 94
                         }),
                         property: newNode(95, {
-                          type: "PrivateName",
+                          type: "PrivateIdentifier",
                           end: 102,
                           name: "secret"
                         }),
@@ -737,11 +737,11 @@ describe("acorn-stage3", () => {
                             end: 253,
                             body: [
                               newNode(166, {
-                                type: "FieldDefinition",
+                                type: "PropertyDefinition",
                                 end: 173,
                                 computed: false,
                                 key: newNode(166, {
-                                  type: "PrivateName",
+                                  type: "PrivateIdentifier",
                                   end: 173,
                                   name: "secret"
                                 }),
@@ -792,7 +792,7 @@ describe("acorn-stage3", () => {
                                               end: 218
                                             }),
                                             property: newNode(219, {
-                                              type: "PrivateName",
+                                              type: "PrivateIdentifier",
                                               end: 226,
                                               name: "secret"
                                             }),
@@ -826,7 +826,7 @@ describe("acorn-stage3", () => {
                                 end: 259
                               }),
                               property: newNode(260, {
-                                type: "PrivateName",
+                                type: "PrivateIdentifier",
                                 end: 270,
                                 name: "getSecret"
                               }),


### PR DESCRIPTION
FieldDefinition -> PropertyDefinition
PrivateName -> PrivateIdentifier

---

~~As the top-level package (and therefore the one depended on most by others), perhaps some more needs to be done to advertise that this is a breaking change than in the previous PRs.~~

^ I think this is addressed by updating the CHANGELOG.md

Previous PRs building up to this:
- https://github.com/acornjs/acorn-private-class-elements/pull/16
- https://github.com/acornjs/acorn-class-fields/pull/16
- https://github.com/acornjs/acorn-static-class-features/pull/8
- https://github.com/acornjs/acorn-private-methods/pull/6